### PR TITLE
RejectImmediatelyOnCondition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:12.16.1
       - image: ethereum/client-go
         entrypoint: /bin/sh
         command: -c "yes '' | geth --dev --dev.period 15 --http --http.addr '0.0.0.0' --http.port 8545 --http.api 'eth,net,web3,account,admin,personal' --unlock '0' --allow-insecure-unlock"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     docker:
       - image: circleci/node:12.16.1
-      - image: ethereum/client-go
+      - image: ethereum/client-go:v1.9.14
         entrypoint: /bin/sh
         command: -c "yes '' | geth --dev --dev.period 15 --http --http.addr '0.0.0.0' --http.port 8545 --http.api 'eth,net,web3,account,admin,personal' --unlock '0' --allow-insecure-unlock"
     steps:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,37 @@ const tx = await ynatm(PROVIDER_URL).send({
 });
 ```
 
+### Error Handling with `rejectImmediatelyOnCondition`
+
+The expected behavior when the transaction manager hits an error is to:
+1. Check if the error meets the condition specified in `rejectImmediatelyOnCondition` (Defaults to checking for reverts)
+    - If the condition is met, all future transactions are cancelled the the promise is rejected
+2. Checks to see if all the transactions have failed
+    - If all transactions have failed, reject the last error
+3. Keep trying
+
+You can override the `rejectImmediatelyOnCondition` like so:
+
+```javascript
+const ynatm = require("ynatm");
+
+const rejectOnAll = () => true
+
+const tx = await ynatm(PROVIDER_URL).send({
+  transaction: {
+    from: SENDER_ADDRESS,
+    to: CONTRACT_ADDRESS,
+    data: IContract.encodeFunctionData("functionName", [params]),
+  },
+  sendTransactionFunction: (tx) => wallet.sendTransaction(tx),
+  minGasPrice: ynatm.toGwei(1),
+  maxGasPrice: ynatm.toGwei(20),
+  gasPriceScalingFunction: ynatm.LINEAR(5),
+  delay: 15000,
+  rejectImmediatelyOnCondition: rejectOnAll
+});
+```
+
 ### Ethers
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynatm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "You Need A Transaction Manager (YNATM)",
   "main": "index.js",
   "repository": "git@github.com:kendricktan/ynatm.git",

--- a/tests/ethers.test.js
+++ b/tests/ethers.test.js
@@ -102,16 +102,13 @@ test("contract data override", async function () {
   expectEqBN(finalState, overrideState);
 });
 
-test(`does not retry on revert`, async () => {
-  const nonce = await provider.getTransactionCount(signerAddress);
-
+test(`does not retry on revert`, async function () {
   const transaction = {
     from: signerAddress,
     to: ethers.constants.AddressZero,
     data: "0x1111111111111111",
     value: ethers.utils.parseEther("1"),
-    gasLimit: 21000,
-    nonce,
+    gasLimit: 100000,
   };
 
   // Expect some error throw within 15 seconds
@@ -125,4 +122,4 @@ test(`does not retry on revert`, async () => {
       delay: 10000,
     })
   ).rejects.toThrow("revert");
-}, 15000);
+});

--- a/tests/ethers.test.js
+++ b/tests/ethers.test.js
@@ -118,10 +118,10 @@ test(`does not retry on revert`, async function () {
       minGasPrice: ynatm.toGwei(1),
       maxGasPrice: ynatm.toGwei(2),
       gasPriceScalingFunction: ynatm.LINEAR(1),
-      delay: 100000,
+      delay: 120000,
     })
   ).rejects.toThrow("revert");
-}, 15000);
+});
 
 test(`throws on all errors`, async function () {
   // Make sure this isn't the first tx as its using nonce of 0
@@ -140,8 +140,8 @@ test(`throws on all errors`, async function () {
       minGasPrice: ynatm.toGwei(1),
       maxGasPrice: ynatm.toGwei(2),
       gasPriceScalingFunction: ynatm.LINEAR(1),
-      delay: 100000,
+      delay: 120000,
       rejectImmediatelyOnCondition: () => true,
     })
   ).rejects.toThrow("nonce");
-}, 15000);
+});

--- a/tests/ethers.test.js
+++ b/tests/ethers.test.js
@@ -52,7 +52,7 @@ test("simple override", async function () {
   });
   const { transactionHash } = await tx.wait();
 
-  await provider.waitForTransaction(transactionHash, 2, 120000);
+  await provider.waitForTransaction(transactionHash, 3, 120000);
 
   const { gasPrice } = await provider.getTransaction(transactionHash);
 
@@ -96,7 +96,7 @@ test("contract data override", async function () {
   });
   const { transactionHash } = await tx.wait();
 
-  await provider.waitForTransaction(transactionHash, 2, 120000);
+  await provider.waitForTransaction(transactionHash, 3, 120000);
 
   const finalState = await StateMachine.state();
   expectEqBN(finalState, overrideState);

--- a/tests/ethers.test.js
+++ b/tests/ethers.test.js
@@ -16,12 +16,12 @@ beforeAll(async function () {
   signerAddress = await signer.getAddress();
 
   // Deploys the token contract and gets related interface
-  const tokenFactory = new ethers.ContractFactory(abi, bytecode, signer);
-  StateMachine = await tokenFactory.deploy();
+  const Factory = new ethers.ContractFactory(abi, bytecode, signer);
+  StateMachine = await Factory.deploy();
   const { transactionHash } = await StateMachine.deployTransaction.wait();
 
   // Waits for 2 confirmations
-  await provider.waitForTransaction(transactionHash, 2, 120000);
+  await provider.waitForTransaction(transactionHash, 1, 120000);
   IStateMachine = StateMachine.interface;
 });
 
@@ -96,7 +96,7 @@ test("contract data override", async function () {
   });
   const { transactionHash } = await tx.wait();
 
-  await provider.waitForTransaction(transactionHash, 3, 120000);
+  await provider.waitForTransaction(transactionHash, 1, 120000);
 
   const finalState = await StateMachine.state();
   expectEqBN(finalState, overrideState);
@@ -111,15 +111,37 @@ test(`does not retry on revert`, async function () {
     gasLimit: 100000,
   };
 
-  // Expect some error throw within 15 seconds
   expect(
     ynatm(PROVIDER_URL).send({
       transaction,
       sendTransactionFunction: (tx) => signer.sendTransaction(tx),
       minGasPrice: ynatm.toGwei(1),
-      maxGasPrice: ynatm.toGwei(5),
+      maxGasPrice: ynatm.toGwei(2),
       gasPriceScalingFunction: ynatm.LINEAR(1),
-      delay: 10000,
+      delay: 100000,
     })
   ).rejects.toThrow("revert");
-});
+}, 15000);
+
+test(`throws on all errors`, async function () {
+  // Make sure this isn't the first tx as its using nonce of 0
+  const transaction = {
+    from: signerAddress,
+    to: signerAddress,
+    nonce: 0,
+    value: ethers.utils.parseEther("1"),
+    gasLimit: 100000,
+  };
+
+  expect(
+    ynatm(PROVIDER_URL).send({
+      transaction,
+      sendTransactionFunction: (tx) => signer.sendTransaction(tx),
+      minGasPrice: ynatm.toGwei(1),
+      maxGasPrice: ynatm.toGwei(2),
+      gasPriceScalingFunction: ynatm.LINEAR(1),
+      delay: 100000,
+      rejectImmediatelyOnCondition: () => true,
+    })
+  ).rejects.toThrow("nonce");
+}, 15000);

--- a/tests/web3.test.js
+++ b/tests/web3.test.js
@@ -5,7 +5,7 @@ const { BigNumber } = require("ethers");
 const { abi, bytecode } = require("./contracts/StateMachine.json");
 const { expectEqBN, expectGtBN, PROVIDER_URL } = require("./common");
 
-const web3 = new Web3(PROVIDER_URL, null, { transactionConfirmationBlocks: 2 });
+const web3 = new Web3(PROVIDER_URL, null, { transactionConfirmationBlocks: 1 });
 
 let StateMachine;
 let signerAddress;

--- a/tests/web3.test.js
+++ b/tests/web3.test.js
@@ -33,7 +33,7 @@ test("simple override", async function () {
     to: signerAddress,
     data: "0x",
     nonce,
-    gasLimit: 21000,
+    gas: 21000,
     gasPrice: initialGasPrice,
   };
 
@@ -70,7 +70,7 @@ test("contract data override", async function () {
     to: StateMachine.options.address,
     data: initialData,
     nonce,
-    gasLimit: 100000,
+    gas: 100000,
     gasPrice: initialGasPrice,
   };
 


### PR DESCRIPTION
https://github.com/kendricktan/ynatm/issues/2

The expected behavior when the transaction manager hits an error is to:
1. Check if the error meets the condition specified in `rejectImmediatelyOnCondition` (Defaults to checking for reverts)
    - If the condition is met, all future transactions are cancelled the the promise is rejected
2. Checks to see if all the transactions have failed
    - If all transactions have failed, reject the last error
3. Keep trying

You can override the `rejectImmediatelyOnCondition` like so:

```javascript
const ynatm = require("ynatm");
const rejectOnAll = () => true
const tx = await ynatm(PROVIDER_URL).send({
  transaction: {
    from: SENDER_ADDRESS,
    to: CONTRACT_ADDRESS,
    data: IContract.encodeFunctionData("functionName", [params]),
  },
  sendTransactionFunction: (tx) => wallet.sendTransaction(tx),
  minGasPrice: ynatm.toGwei(1),
  maxGasPrice: ynatm.toGwei(20),
  gasPriceScalingFunction: ynatm.LINEAR(5),
  delay: 15000,
  rejectImmediatelyOnCondition: rejectOnAll
});
```